### PR TITLE
Moved DConf 2015 descriptions from future tense to past tense

### DIFF
--- a/2015/index.dd
+++ b/2015/index.dd
@@ -1,10 +1,10 @@
 Ddoc
 
-$(T h1,,DConf 2015 Registration is open!)
+$(T h1,,DConf 2015 has successfully concluded!)
 
-$(T h2,,Please join us at DConf 2015, the conference of the D programming language at Utah Valley University in Orem, UT, May 27-29 2015.)
+$(T h2,,DConf 2015, the conference of the D programming language, took place at Utah Valley University in Orem, UT, May 27-29 2015.)
 
-$(P We are thrilled to benefit of the generous hosting of Utah Valley University's Computer Science Department at its beautiful campus. $(HTTP uvu.edu/cs, UVU/CS) has an excellent track record of preparing students for real-world software engineering jobs, and has been a long-time supporter of D by teaching it to its students. Special thanks are due Department Chair $(HTTP uvu.edu/profpages/profiles/show/user_id/67, Chuck Allison).)
+$(P We were thrilled to benefit from the generous hosting of Utah Valley University's Computer Science Department at its beautiful campus. $(HTTP uvu.edu/cs, UVU/CS) has an excellent track record of preparing students for real-world software engineering jobs, and has been a long-time supporter of D by teaching it to its students. Special thanks are due Department Chair $(HTTP uvu.edu/profpages/profiles/show/user_id/67, Chuck Allison).)
 
 $(P The D programming language has continued to grow through 2014, undergoing a $(HTTP erdani.com/d/downloads.daily.png, three-fold increase) of $(HTTP dlang.org/download.html, dmd) daily downloads from the main site. Quality and
 stability have improved all across the board for $(LINK2 http://github.com/D
@@ -13,23 +13,19 @@ https://github.com/ldc-developers, ldc), and the $(LINK2 http://github.com/D
 -Programming-Language/phobos, standard library).)
 
 $(P DConf is the main face-to-face event for everyone and everything related to
-the D language and environment. Utah Valley University will host the conference at its campus in Orem, UT. We aim at making this next edition even bigger, better, and badder than DConf 2014!)
+the D language and environment. Utah Valley University hosted the conference at its campus in Orem, UT)
 
 $(T h2,,Schedule Highlights)
 
-$(P Take a look at our $(LINK schedule) for topics that include language evolution, practice, and experience reports. Our speakers are a balanced collection of established and up-and-coming experts.)
+$(P Take a look at our $(LINK schedule) for topics that include language evolution, practice, and experience reports. Our speakers comprised a balanced collection of established and up-and-coming experts.)
 
-$(P Want to tune in to the language's strategic vision and direction? Tune into $(TALK bright, Walter Bright)'s and $(TALK alexandrescu, Andrei Alexandrescu)'s keynotes. Core contributor $(TALK murphy, Daniel Murphy) will discuss automatic conversion of C++ code to D for achieving D compiler bootstrapping.)
-
-$(P Hate garbage? So do we! Release czar and all-around D guru $(TALK nowak, Martin Nowak) has recently worked on dramatic improvements of D's garbage collector, which he will share, along with tips and tricks for better memory performance, in his talk.)
+$(P Want to tune in to the language's strategic vision and direction? Tune into $(TALK bright, Walter Bright)'s and $(TALK alexandrescu, Andrei Alexandrescu)'s keynotes. Core contributor $(TALK murphy, Daniel Murphy) discussed automatic conversion of C++ code to D for achieving D compiler bootstrapping.)
 
 $(P Don't miss experience reports from using D in varied domains such as $(TALK zvibel, large-scale storage systems), $(TALK smith, hedge funds), $(TALK isaacson, database drivers), $(TALK colvin, scientific computing), $(TALK allison, teaching at university level), and $(TALK gubler, learning).)
 
 $(P What's the deal with them ranges everybody talks about? Glad you asked! Listen to D veteran contributor $(TALK davis, Jonathan M. Davis) is up for an introduction. Also learn about $(TALK ruppe, dynamic types) and $(TALK wakeling, random number generation).)
 
-An assortment of talks featuring topics such as $(TALK schott, tooling), $(TALK nadlinger, runtime support), $(TALK sechet, memory hierarchy), $(TALK strasuns, porting large codebases), and $(TALK neves, behavior-driven development) complete a strong program.)
-
-$(P $(LINK2 registration.html, Register now.) See you there!)
+An assortment of talks featuring topics such as $(TALK schott, tooling), $(TALK nadlinger, runtime support), $(TALK sechet, memory hierarchy), $(TALK strasuns, porting large codebases), and $(TALK neves, behavior-driven development) completed a strong program.)
 
 Macros:
 


### PR DESCRIPTION
I've made some basis s/future/past/g changes. 

Quite important to get merged though as websites that refer to upcoming events that are already in the past never look that good....