### PR TITLE
replace invalid video link for nadlinger and add one for sechet

### DIFF
--- a/2015/talks/nadlinger.dd
+++ b/2015/talks/nadlinger.dd
@@ -12,7 +12,7 @@ SPEAKER_SHORT = nadlinger
 
 SLIDES = $(SLIDES_YES)
 
-VIDEO_URL_Y = https://www.youtube.com/watch?v=rmRmfoKxMCE
+VIDEO_URL_Y = https://www.youtube.com/watch?v=WzXe2kT9sEo
 
 VIDEO_SD_URL =
 

--- a/2015/talks/sechet.dd
+++ b/2015/talks/sechet.dd
@@ -14,11 +14,11 @@ SPEAKER_URL = https://github.com/deadalnix
 
 SLIDES = $(SLIDES_YES)
 
-VIDEO_URL_Y =
+VIDEO_URL_Y = https://www.youtube.com/watch?v=ScHZsO1RzAI
 
 VIDEO_URL_A =
 
-VIDEO = $(VIDEO_NO)
+VIDEO = $(VIDEO_YES)
 
 SPEAKER_PIC = http://worldcubeassociation.org/results/upload/a2008SECH01.jpg
 


### PR DESCRIPTION
i was checking out 2015 videos and the link for the talk by nadlinger was invalid and the link for the talk by sechet was missing. i've corrected the former and added the latter. 

also, i think the website needs a re-generation because andrei and some other speakers have links for youtube but they are not visible on the website. feel free to ignore the PR if that is intentional.